### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,9 +129,8 @@
     <ul class='item-lists'>
       <% @items.each do |item| %>
       <li class='list'>
-       <%#= link_to "#" do %>
         <div class='item-img-content'>         
-          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+          <%= link_to image_tag(item.image, class: "item-img"), item_path(item.id)  if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <!--div class='sold-out'>
@@ -142,7 +141,7 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= item.item_name %>
+            <%= link_to item.item_name, item_path(item.id) %>
           </h3>
           <div class='item-price'>
             <span><%= item.price %>円<br><%= item.postage.name %></span> 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,9 +128,10 @@
     </div>
     <ul class='item-lists'>
       <% @items.each do |item| %>
+      <%= link_to item_path(item.id) do %>
       <li class='list'>
         <div class='item-img-content'>         
-          <%= link_to image_tag(item.image, class: "item-img"), item_path(item.id)  if item.image.attached? %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <!--div class='sold-out'>
@@ -141,7 +142,7 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= link_to item.item_name, item_path(item.id) %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
             <span><%= item.price %>円<br><%= item.postage.name %></span> 
@@ -151,6 +152,7 @@
             </div>
           </div>
         </div>
+       <% end %>
        <% end %>
       </li>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -99,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,63 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <!--div class="sold-out"-->
+        <!--<span>Sold Out!!</span>-->
+      <!--/div-->
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.postage.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>    
+    <% elsif user_signed_in? %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.take_days.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +100,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items,  only: [ :index, :new, :create, ]
+  resources :items,  only: [ :index, :new, :create, :show ]
 end


### PR DESCRIPTION
# What
商品詳細表示機能の実装として、商品詳細表示ページにて、商品の詳細情報を表示するように実装した。

ログイン状態で自身出品商品の詳細ページへ： https://gyazo.com/e775c9d8529250156272d857ab53203a
ログイン状態で他人出品商品の詳細ページへ： https://gyazo.com/a729bc1694f4ced8e1888b718b0a491f
ログアウト状態で商品詳細ページへ： https://gyazo.com/f74294da37250e0f49b4f3af04e40861

# Why
商品詳細表示機能を実装するため。